### PR TITLE
Make extension compatible with channels + upgrade manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "Force Slack in Browser",
   "description": "Force Slack to open archive links in the browser not the desktop app.",
-  "version": "0.0.1",
+  "version": "0.2.0",
   "homepage_url": "https://github.com/wearhere/ForceSlackInBrowser",
   "author": "Jeffrey Wear",
   "icons": {
@@ -13,6 +13,6 @@
     "js": [
       "src/app.js"
     ],
-    "run_at": "document_start"
+    "run_at": "document_end"
   }]
 }

--- a/src/app.js
+++ b/src/app.js
@@ -2,7 +2,28 @@
  * Skip the archive page: https://mixmax.slack.com/archives/CB7SHUDMW/p1559265229005700
  * -> https://mixmax.slack.com/messages/CB7SHUDMW/p1559265229005700
  *
- * This runs at document start so we can execute as quickly as possible, mostly to preempt Slack's
- * annoying JS that tries to open the link in the desktop app, but also for a fast UX.
+ * We cannot simply replace "archives" by "messages" in the URL because this breaks vanity URLs/channels names
+ * links, which first need the vanity name --> UUID translation.
+ * eg. something.slack.com/archives/my-channel needs to be translated to something.slack.com/archives/CB7SHUXYZ
+ * and only the Slack backend can do so.
+ * Executing on document_end rather than document_start also seems to make no difference in being able to skip
+ * Slack's javascript intent which would open the Slack app if you had it installed.
  */
-window.location.href = window.location.href.replace('/archives/', '/messages/');
+
+// Get all links, and keep the one which is the "open in browser" link
+const filteredLinks = Array.from(document.getElementsByTagName("a")).filter(
+    (link) => {
+        return link.href.indexOf("/messages/") !== -1;
+    }
+);
+// If we found it, use it
+if (filteredLinks.length > 0) {
+    const target = filteredLinks[0];
+    window.location.href = target.href;
+} else {
+    // If we did _not_ find it, fall back to the earlier extension's behavior of using the window URL:
+    window.location.href = window.location.href.replace(
+        "/archives/",
+        "/messages/"
+    );
+}


### PR DESCRIPTION
Two changes:

1. Make the extension work with all types of archive links, including the ones using vanity URLs/slack channels names
2. Upgrade the manifest as manifest V2 extensions are going to be offline by Google in 2023: https://developer.chrome.com/blog/mv2-transition/

@wearhere I imagine the Chrome store push needs to be manual, it's not automated?